### PR TITLE
fix "Waiting for network..." bug

### DIFF
--- a/setup-phase-4.sh
+++ b/setup-phase-4.sh
@@ -45,7 +45,7 @@ sleep 2
 
 # Ask user for installing steamvr
 echog "Installed base packages and Steam. Opening steam. Please install SteamVR from it."
-steam &>/dev/null &
+steam -vgui &>/dev/null &
 echog "Enabling ctrl+c prevention."
 trap 'echog "Oops you have pressed ctrl+c which would have stopped this setup, dont worry, i prevented it from doing that"' 2
 echog "Install SteamVR from Steam and press enter here"


### PR DESCRIPTION
this change forces steam to run in the old UI because the new UI never loads for some people inside of distrobox. This is only an issue when you start steam for the first time to install steamVR. the new UI is able to be loaded after this though, so it's only necessary here.

heres a screenshot of the issue without `-vgui`
![image](https://github.com/alvr-org/ALVR-Distrobox-Linux-Guide/assets/55332100/d4e5c8a8-29a5-4ee6-89f3-a589ce307510)

edit: this wouldn't affect people who aren't experiencing the bug because the old UI still works perfectly fine and it will load the new UI the next time steam is opened.

