### PR TITLE
Update setup-phase-1-2.sh

### DIFF
--- a/setup-phase-1-2.sh
+++ b/setup-phase-1-2.sh
@@ -124,8 +124,8 @@ if [ "$(detect_gpu_count)" -ne 1 ]; then
    echor "Or proceed with system-wide installation (using appimage) instead - with optimus manager for Nvidia to use only Nvidia"
    exit 1
 fi
-disk_space=$(df -Pkh . | sed 1d | grep -v used | awk '{ print $4 "\t" }')
-disk_space=${disk_space::-1}
+disk_space=$(df -Pk . | sed 1d | grep -v used | awk '{ print $4 "\t" }')
+disk_space=$(( 10#${disk_space} / 1024 / 1024 ))
 if (( disk_space < 15)); then
    echor "Installation might require up to least 15 gb during installation and close to 10 gb including steamvr after."
    echor "You have less than 15 gb of free space available, exiting."


### PR DESCRIPTION
tweak disk_space check logic:
* for me {disk_space::-1} returned {disk_space} (including suffix), causing following (( query )) to fail;
* with {disk_space::-2}, a multi-terabyte volume could return available space < 15, and cause exit incorrectly