### PR TITLE
Change alvr installation from aur to appimage

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -12,6 +12,9 @@ prefix="installation-lilipod"
 container_name="arch-alvr"
 
 # Links
+ALVR_STABLE_STREAMER_LINK='https://github.com/alvr-org/ALVR/releases/download/v20.6.1/ALVR-x86_64.AppImage'
+ALVR_NIGHTLY_STREAMER_LINK='https://github.com/alvr-org/ALVR-nightly/releases/latest/download/ALVR-x86_64.AppImage'
+ALVR_STREAMER_NAME='ALVR-x86_64.AppImage'
 ALVR_APK_LINK='https://github.com/alvr-org/ALVR/releases/download/v20.6.1/alvr_client_android.apk'
 NIGHTLY_ALVR_APK_LINK='https://github.com/alvr-org/ALVR-nightly/releases/latest/download/alvr_client_android.apk'
 ALVR_APK_NAME='alvr_client_android.apk'

--- a/helper-functions.sh
+++ b/helper-functions.sh
@@ -16,8 +16,8 @@ function echor() {
    echo -e "${RED}${STEP_INDEX}${NC} : ${RED}$1${NC}"
    sleep 0.5
 }
-function cleanup_alvr() {
-   echog "Cleaning up ALVR"
+function cleanup_steamvr() {
+   echog "Cleaning up SteamVR"
    for vrp in "${STEAMVR_PROCESSES[@]}"; do
       pkill -f $vrp
    done

--- a/open-container.sh
+++ b/open-container.sh
@@ -17,4 +17,4 @@ if [ "$(sanity_check_for_container)" -eq 1 ]; then
    exit 1
 fi
 
-distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8"
+distrobox enter --name "$container_name" --additional-flags "--env PATH=$prefix/$container_name/alvr_streamer_linux/usr/bin:$PATH --env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8"

--- a/setup-phase-1-2.sh
+++ b/setup-phase-1-2.sh
@@ -112,7 +112,7 @@ function phase2_distrobox_container_creation() {
       exit 1
    fi
    distrobox stop "$container_name" --yes
-   distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- ./setup-phase-4.sh
+   distrobox enter --name "$container_name" --additional-flags "--env PATH=$prefix/$container_name/alvr_streamer_linux/usr/bin:$PATH --env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- ./setup-phase-4.sh
    if [ $? -ne 0 ]; then
       echor "Couldn't install distrobox container first time at phase 4, please report setup.log to https://github.com/alvr-org/ALVR-Distrobox-Linux-Guide/issues."
       # envs are required! otherwise first time install won't have those env vars, despite them being even in bashrc, locale conf, profiles, etc

--- a/start-alvr.sh
+++ b/start-alvr.sh
@@ -20,4 +20,4 @@ fi
 echog "Starting up Steam"
 distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- steam &>/dev/null &
 echog "Starting up ALVR"
-distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- alvr_dashboard
+distrobox enter --name "$container_name" --additional-flags "--env PATH=$prefix/$container_name/alvr_streamer_linux/usr/bin:$PATH --env XDG_CURRENT_DESKTOP=X-Generic --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- alvr_dashboard

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,7 +29,7 @@ cd $prefix/distrobox-$distrobox_version*
 ./uninstall --prefix "$prefix"
 
 echor "Be careful, superuser access requesting for deletion!"
-echor "Confirm deletion of $prefix folder? (y/n)"
+echor "Confirm deletion of $prefix folder? (y/N)"
 read -r CONFIRM_DELETE
 if [ "$CONFIRM_DELETE" = "y" ] || [ "$CONFIRM_DELETE" = "Y" ]; then
    "$ROOT_PERMS_COMMAND" rm -rf "$prefix"

--- a/update-vr-apps.sh
+++ b/update-vr-apps.sh
@@ -17,8 +17,7 @@ if [ "$(sanity_check_for_container)" -eq 1 ]; then
    exit 1
 fi
 
-echog "Updating arch container, alvr"
-distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" -- 'paru -q --noprogressbar -Sy archlinux-keyring --noconfirm'
+echog "Updating alvr"
 (
    cd "$prefix" || exit 1
    rm "$ALVR_STREAMER_NAME"

--- a/update-vr-apps.sh
+++ b/update-vr-apps.sh
@@ -19,26 +19,19 @@ fi
 
 echog "Updating arch container, alvr"
 distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" -- 'paru -q --noprogressbar -Sy archlinux-keyring --noconfirm'
-distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" -- 'paru -Q alvr'
-ALVR_STABLE_OUT=$?
-distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" -- 'paru -Q alvr-git'
-ALVR_NIGHTLY_OUT=$?
-if [[ $IS_NIGHTLY -eq 1 ]]; then
-   if [[ $ALVR_STABLE_OUT -eq 0 ]]; then
-      distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" \
-         -- 'paru -Runs alvr --noconfirm'
+(
+   cd "$prefix" || exit 1
+   rm "$ALVR_STREAMER_NAME"
+   rm -r "$container_name/alvr_streamer_linux"
+   if [[ $IS_NIGHTLY -eq 1 ]]; then
+      wget -q --show-progress "$ALVR_NIGHTLY_STREAMER_LINK" || exit 1
+   else
+      wget -q --show-progress "$ALVR_STABLE_STREAMER_LINK" || exit 1
    fi
-   distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" \
-      -- 'paru -q --noprogressbar -Syu alvr-git --noconfirm'
-else
-   if [[ $ALVR_NIGHTLY_OUT -eq 0 ]]; then
-      distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" \
-         -- 'paru -Runs alvr-git --noconfirm'
-   fi
-   distrobox enter --name "$container_name" --additional-flags "--env XDG_CURRENT_DESKTOP=X-Generic" \
-      -- 'paru -q --noprogressbar -Syu alvr --noconfirm'
-fi
-
+   chmod +x "$ALVR_STREAMER_NAME"
+   ./"$ALVR_STREAMER_NAME" --appimage-extract
+   mv squashfs-root "$container_name/alvr_streamer_linux" || exit 1
+)
 echog "Downloading alvr apk"
 rm "$prefix/alvr_client_android.apk"
 if [[ $IS_NIGHTLY -eq 1 ]]; then


### PR DESCRIPTION
AUR was taking too long to compile, and almost impossible to do so on deck, so using appimage like before now.